### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "cpp"
+run = "run"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Program Challange Section 9 and 11
 I have recreated the program with functions!
+[![Run on Repl.it](https://repl.it/badge/github/ebobocea/Program-Challange-Section-9-11)](https://repl.it/github/ebobocea/Program-Challange-Section-9-11)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ebobocea/Program-Challange-Section-9-11).